### PR TITLE
feat(status): filter completed items from /joenet status

### DIFF
--- a/src/main/java/org/fitznet/commands/JoenetCommands.java
+++ b/src/main/java/org/fitznet/commands/JoenetCommands.java
@@ -150,11 +150,23 @@ public class JoenetCommands extends ListenerAdapter {
             return "✅ Queue is empty";
         }
 
-        int cap = Math.min(items.size(), 10);
+        List<?> activeItems = items.stream()
+                .filter(item -> {
+                    String s = item instanceof RadarrQueueItemDto r ? r.getStatus()
+                             : item instanceof SonarrQueueItemDto sq ? sq.getStatus() : null;
+                    return s == null || !s.equalsIgnoreCase("completed");
+                })
+                .toList();
+
+        if (activeItems.isEmpty()) {
+            return "✅ Queue is empty";
+        }
+
+        int cap = Math.min(activeItems.size(), 10);
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < cap; i++) {
-            Object rawItem = items.get(i);
+            Object rawItem = activeItems.get(i);
             String title;
             String status;
             String trackedStatus;
@@ -216,8 +228,8 @@ public class JoenetCommands extends ListenerAdapter {
             sb.append("\n");
         }
 
-        if (items.size() > cap) {
-            sb.append("*…and ").append(items.size() - cap).append(" more*");
+        if (activeItems.size() > cap) {
+            sb.append("*…and ").append(activeItems.size() - cap).append(" more*");
         }
 
         String result = sb.toString().trim();

--- a/src/test/java/org/fitznet/commands/JoenetCommandsStatusTest.java
+++ b/src/test/java/org/fitznet/commands/JoenetCommandsStatusTest.java
@@ -21,6 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
@@ -143,6 +146,47 @@ class JoenetCommandsStatusTest {
         verify(radarrService, times(1)).getQueueDetails();
         verify(sonarrService, times(1)).getQueueDetails();
         verify(hook, times(1)).editOriginalEmbeds(any(MessageEmbed.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStatusCommand_CompletedItemsFilteredOut() {
+        List<RadarrQueueItemDto> radarrItems = Arrays.asList(
+                createRadarrItem("Completed Movie", "completed", 1_000_000.0, 0.0),
+                createRadarrItem("Downloading Movie", "downloading", 1_000_000.0, 400_000.0)
+        );
+        when(radarrService.getQueueDetails()).thenReturn(radarrItems);
+        when(sonarrService.getQueueDetails()).thenReturn(Collections.emptyList());
+
+        joenetCommands.onSlashCommandInteraction(event);
+
+        ArgumentCaptor<MessageEmbed> captor = ArgumentCaptor.forClass(MessageEmbed.class);
+        verify(hook).editOriginalEmbeds(captor.capture());
+        String radarrField = captor.getValue().getFields().get(0).getValue();
+        assertThat(radarrField).doesNotContain("Completed Movie");
+        assertThat(radarrField).contains("Downloading Movie");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStatusCommand_AllCompletedShowsQueueEmpty() {
+        List<RadarrQueueItemDto> radarrItems = Arrays.asList(
+                createRadarrItem("Completed Movie A", "completed", 1_000_000.0, 0.0),
+                createRadarrItem("Completed Movie B", "COMPLETED", 800_000.0, 0.0)
+        );
+        List<SonarrQueueItemDto> sonarrItems = Arrays.asList(
+                createSonarrItem("Completed Show S01E01", "Completed", 500_000.0, 0.0)
+        );
+        when(radarrService.getQueueDetails()).thenReturn(radarrItems);
+        when(sonarrService.getQueueDetails()).thenReturn(sonarrItems);
+
+        joenetCommands.onSlashCommandInteraction(event);
+
+        ArgumentCaptor<MessageEmbed> captor = ArgumentCaptor.forClass(MessageEmbed.class);
+        verify(hook).editOriginalEmbeds(captor.capture());
+        MessageEmbed embed = captor.getValue();
+        assertThat(embed.getFields().get(0).getValue()).isEqualTo("✅ Queue is empty");
+        assertThat(embed.getFields().get(1).getValue()).isEqualTo("✅ Queue is empty");
     }
 
     // ── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `/joenet status` no longer shows completed downloads in the queue embed
- Filter is case-insensitive (`completed`, `COMPLETED`, `Completed` all excluded)
- When all items in a section are completed, the section shows `✅ Queue is empty` as normal

## Test plan

- [x] `testStatusCommand_CompletedItemsFilteredOut` — mixed queue (completed + downloading): completed title absent from embed, active title present
- [x] `testStatusCommand_AllCompletedShowsQueueEmpty` — all items completed (Radarr + Sonarr): both embed fields render `✅ Queue is empty`
- [x] All 6 existing status tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)