### PR TITLE
feat(whitelist): /whitelist command to manage Minecraft whitelist over RCON

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Discord bot built with Java and Spring Boot that tracks voice channel joins an
 - 📊 **Reliable Statistics** - Robust data persistence with JSON serialization and MongoDB-ready schema
 - 🎬 **Media Download Integration** - Search and download movies via Radarr integration
 - 📺 **TV Show Downloads** - Search and download TV shows via Sonarr with flexible season selection or individual episode targeting
+- ⛏️ **Minecraft Whitelist** - Role-gated `/whitelist` command adds players to the Minecraft server over RCON
 
 ## Tech Stack
 
@@ -111,6 +112,19 @@ flowchart TD
 #### `/joenet status`
 View the current Radarr and Sonarr download queues, including progress percentages and ETAs.
 
+#### `/whitelist <username>`
+Adds a player to the Minecraft server whitelist over RCON.
+- **Access**: gated to members holding the role configured via `/setwhitelistrole` (administrators are always allowed). If no role is set, only admins can use it.
+- **Validation**: the username must match Minecraft's rules (`3-16` characters, letters/digits/underscores) — this also prevents RCON command injection.
+- The server's response (e.g. *"Added Steve to the whitelist"*) is shown back ephemerally.
+- **Example**: `/whitelist Steve`
+
+> Crawlers/bots are kept out by the Minecraft server itself: set `white-list=true` and `online-mode=true` in `server.properties`. This command only manages who is allowed in.
+
+#### `/setwhitelistrole <role>`
+Sets which Discord role may use `/whitelist`. Requires the **Manage Server** permission.
+- **Example**: `/setwhitelistrole @Trusted`
+
 ### REST API Endpoints
 
 The bot provides HTTP endpoints for management:
@@ -166,6 +180,30 @@ joenet.sonarr.root-folder-path=${JOENET_SONARR_ROOT_FOLDER_PATH:P:\\\\Plex\\\\TV
 - **Individual Episode Download**: Pick a single episode from any season already in your Sonarr library — useful for re-triggering missed downloads
 - **Interactive Discord UI**: Button-driven interface with dropdown menus
 - **Error Handling**: Graceful handling of duplicate media and connection errors
+
+### Minecraft RCON Configuration
+The `/whitelist` command talks to the Minecraft server over RCON. Configure the endpoint in `application.properties`:
+
+```properties
+# Minecraft RCON (must match server.properties on the MC server)
+minecraft.rcon.host=${MINECRAFT_RCON_HOST:your-mc-host-here}
+minecraft.rcon.port=${MINECRAFT_RCON_PORT:25575}
+minecraft.rcon.password=${MINECRAFT_RCON_PASSWORD:changeme}
+```
+
+On the Minecraft server, enable RCON and lock the server down in `server.properties`, then restart it:
+
+```properties
+white-list=true
+enforce-whitelist=true
+online-mode=true
+enable-rcon=true
+rcon.port=25575
+rcon.password=<strong-secret>
+```
+
+- `white-list` + `online-mode` keep anonymous/cracked crawler clients out.
+- `enable-rcon` + `rcon.password` let Fitz-Bot manage the whitelist remotely.
 
 ### As Of Date Tracking
 The bot automatically tracks when voice channel monitoring begins for each server:

--- a/src/main/java/org/fitznet/commands/WhitelistCommands.java
+++ b/src/main/java/org/fitznet/commands/WhitelistCommands.java
@@ -1,0 +1,165 @@
+package org.fitznet.commands;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import org.fitznet.data.GuildConfigDatabase;
+import org.fitznet.service.MinecraftRconService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Slash command handler for managing the Minecraft server whitelist.
+ *
+ * <p>{@code /whitelist} is gated to members holding a configurable role (set via
+ * {@code /setwhitelistrole}); administrators are always allowed. Combined with
+ * {@code white-list=true} and {@code online-mode=true} on the server, this keeps
+ * anonymous crawlers off the Minecraft server.</p>
+ */
+@Slf4j
+@Component
+public class WhitelistCommands extends ListenerAdapter {
+
+    static final String WHITELIST = "whitelist";
+    static final String SET_ROLE = "setwhitelistrole";
+
+    private final GuildConfigDatabase configDatabase;
+    private final MinecraftRconService rconService;
+
+    @Autowired
+    public WhitelistCommands(MinecraftRconService rconService) {
+        this(new GuildConfigDatabase(), rconService);
+    }
+
+    /** Package-private constructor for testing with an injected database. */
+    WhitelistCommands(GuildConfigDatabase configDatabase, MinecraftRconService rconService) {
+        this.configDatabase = configDatabase;
+        this.rconService = rconService;
+    }
+
+    /**
+     * Gets the slash command definitions.
+     */
+    public static SlashCommandData[] getCommands() {
+        return new SlashCommandData[]{
+                Commands.slash(WHITELIST, "Add a player to the Minecraft whitelist")
+                        .addOption(OptionType.STRING, "username", "The Minecraft username to whitelist", true),
+                Commands.slash(SET_ROLE, "Set the Discord role allowed to use /whitelist (Admin only)")
+                        .addOption(OptionType.ROLE, "role", "The role that may add players to the whitelist", true)
+        };
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        String name = event.getName();
+        if (!WHITELIST.equals(name) && !SET_ROLE.equals(name)) {
+            return; // Let other handlers process this command
+        }
+
+        log.info("Received slash command: {} from user: {} in guild: {}",
+                name, event.getUser().getName(),
+                event.getGuild() != null ? event.getGuild().getName() : "DM");
+
+        try {
+            if (!event.isAcknowledged()) {
+                event.deferReply(true).queue();
+            }
+
+            if (!event.isFromGuild()) {
+                event.getHook().editOriginal("❌ This command can only be used in a server!").queue();
+                return;
+            }
+
+            switch (name) {
+                case SET_ROLE -> handleSetRole(event);
+                case WHITELIST -> handleWhitelist(event);
+                default -> event.getHook().editOriginal("❌ Unknown command").queue();
+            }
+        } catch (Exception e) {
+            log.error("Error in onSlashCommandInteraction for command: {}", name, e);
+            replyError(event);
+        }
+    }
+
+    private void handleSetRole(SlashCommandInteractionEvent event) {
+        Member member = event.getMember();
+        if (member == null || !member.hasPermission(Permission.MANAGE_SERVER)) {
+            event.getHook().editOriginal("❌ You need the 'Manage Server' permission to use this command!").queue();
+            return;
+        }
+
+        Role role = event.getOption("role").getAsRole();
+        configDatabase.setWhitelistRoleId(event.getGuild().getIdLong(), role.getIdLong());
+        event.getHook().editOriginal("✅ " + role.getAsMention() + " can now use `/whitelist`.").queue();
+    }
+
+    private void handleWhitelist(SlashCommandInteractionEvent event) {
+        if (!isAllowed(event)) {
+            event.getHook().editOriginal(
+                    "❌ You don't have permission to use `/whitelist`. Ask an admin to grant you the whitelist role.").queue();
+            return;
+        }
+
+        String username = event.getOption("username").getAsString().trim();
+        if (!MinecraftRconService.isValidUsername(username)) {
+            event.getHook().editOriginal(
+                    "❌ That doesn't look like a valid Minecraft username (3-16 letters, digits, or underscores).").queue();
+            return;
+        }
+
+        try {
+            String response = rconService.addToWhitelist(username);
+            String message = (response == null || response.isBlank())
+                    ? "✅ Sent `whitelist add " + username + "` to the server."
+                    : "✅ " + response.trim();
+            event.getHook().editOriginal(message).queue();
+            log.info("User {} whitelisted '{}' in guild {}",
+                    event.getMember().getEffectiveName(), username, event.getGuild().getName());
+        } catch (IllegalArgumentException e) {
+            event.getHook().editOriginal("❌ That doesn't look like a valid Minecraft username.").queue();
+        } catch (IOException e) {
+            log.error("Failed to whitelist {} via RCON", username, e);
+            event.getHook().editOriginal("❌ Couldn't reach the Minecraft server. Please try again later.").queue();
+        }
+    }
+
+    /**
+     * A member may use {@code /whitelist} if they are an administrator or hold the
+     * configured whitelist role. If no role is configured, only admins are allowed.
+     */
+    private boolean isAllowed(SlashCommandInteractionEvent event) {
+        Member member = event.getMember();
+        if (member == null) {
+            return false;
+        }
+        if (member.hasPermission(Permission.ADMINISTRATOR)) {
+            return true;
+        }
+        Long roleId = configDatabase.getWhitelistRoleId(event.getGuild().getIdLong());
+        if (roleId == null) {
+            return false;
+        }
+        return member.getRoles().stream().anyMatch(role -> role.getIdLong() == roleId);
+    }
+
+    private void replyError(SlashCommandInteractionEvent event) {
+        try {
+            if (event.isAcknowledged()) {
+                event.getHook().editOriginal("❌ An error occurred while processing your command. Please try again.").queue();
+            } else {
+                event.reply("❌ An error occurred while processing your command. Please try again.")
+                        .setEphemeral(true).queue();
+            }
+        } catch (Exception replyError) {
+            log.error("Failed to send error response", replyError);
+        }
+    }
+}

--- a/src/main/java/org/fitznet/data/GuildConfigDatabase.java
+++ b/src/main/java/org/fitznet/data/GuildConfigDatabase.java
@@ -128,6 +128,30 @@ public class GuildConfigDatabase {
     }
 
     /**
+     * Gets the role ID permitted to use the /whitelist command for a guild.
+     *
+     * @param guildId the Discord guild ID
+     * @return the whitelist role ID, or null if not configured
+     */
+    public Long getWhitelistRoleId(long guildId) {
+        GuildConfig config = guildConfigs.get(guildId);
+        return config != null ? config.getWhitelistRoleId() : null;
+    }
+
+    /**
+     * Sets the role ID permitted to use the /whitelist command for a guild.
+     *
+     * @param guildId the Discord guild ID
+     * @param roleId the Discord role ID
+     */
+    public void setWhitelistRoleId(long guildId, long roleId) {
+        GuildConfig config = guildConfigs.computeIfAbsent(guildId, k -> new GuildConfig());
+        config.setWhitelistRoleId(roleId);
+        saveConfigs();
+        log.info("Set whitelist role for guild {} to {}", guildId, roleId);
+    }
+
+    /**
      * Gets the milestone thresholds for a specific guild.
      *
      * @param guildId the Discord guild ID

--- a/src/main/java/org/fitznet/data/model/GuildConfig.java
+++ b/src/main/java/org/fitznet/data/model/GuildConfig.java
@@ -27,6 +27,12 @@ public class GuildConfig {
     private Long botChannelId;
 
     /**
+     * Discord role ID permitted to use the /whitelist command.
+     * If null, only administrators may add players to the Minecraft whitelist.
+     */
+    private Long whitelistRoleId;
+
+    /**
      * Custom milestone thresholds for this guild.
      * If null, default milestones will be used.
      */

--- a/src/main/java/org/fitznet/service/BotService.java
+++ b/src/main/java/org/fitznet/service/BotService.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
 import org.fitznet.commands.ConfigCommands;
 import org.fitznet.commands.JoenetCommands;
+import org.fitznet.commands.WhitelistCommands;
 import org.fitznet.listener.LoginListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,9 @@ public class BotService {
 
     @Autowired
     private JoenetCommands joenetCommands;
+
+    @Autowired
+    private WhitelistCommands whitelistCommands;
 
     /**
      * -- GETTER --
@@ -61,6 +65,7 @@ public class BotService {
             jda.addEventListener(new LoginListener());
             jda.addEventListener(new ConfigCommands());
             jda.addEventListener(joenetCommands);
+            jda.addEventListener(whitelistCommands);
 
             // Small delay to ensure guild cache is fully populated
             Thread.sleep(2000);
@@ -73,6 +78,7 @@ public class BotService {
             // Combine commands from both handlers
             var allCommands = new java.util.ArrayList<>(java.util.Arrays.asList(ConfigCommands.getCommands()));
             allCommands.addAll(java.util.Arrays.asList(JoenetCommands.getCommands()));
+            allCommands.addAll(java.util.Arrays.asList(WhitelistCommands.getCommands()));
 
             for (var guild : jda.getGuilds()) {
                 guild.updateCommands()
@@ -179,6 +185,7 @@ public class BotService {
             // Combine commands from both handlers
             var allCommands = new java.util.ArrayList<>(java.util.Arrays.asList(ConfigCommands.getCommands()));
             allCommands.addAll(java.util.Arrays.asList(joenetCommands.getCommands()));
+            allCommands.addAll(java.util.Arrays.asList(WhitelistCommands.getCommands()));
 
             var guild = jda.getGuildById(guildId);
             if (guild == null) {

--- a/src/main/java/org/fitznet/service/MinecraftRconService.java
+++ b/src/main/java/org/fitznet/service/MinecraftRconService.java
@@ -1,0 +1,58 @@
+package org.fitznet.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.fitznet.util.RconClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Service for managing the Minecraft server's whitelist over RCON.
+ */
+@Service
+@Slf4j
+public class MinecraftRconService {
+
+    /** Minecraft Java Edition usernames: 3-16 characters, letters/digits/underscore. */
+    private static final Pattern VALID_USERNAME = Pattern.compile("^[A-Za-z0-9_]{3,16}$");
+
+    @Value("${minecraft.rcon.host}")
+    private String host;
+
+    @Value("${minecraft.rcon.port}")
+    private int port;
+
+    @Value("${minecraft.rcon.password}")
+    private String password;
+
+    /**
+     * Validates a Minecraft username. Rejecting anything outside the allowed
+     * character set also prevents RCON command injection (e.g. embedded spaces
+     * or newlines that could append additional commands).
+     */
+    public static boolean isValidUsername(String username) {
+        return username != null && VALID_USERNAME.matcher(username).matches();
+    }
+
+    /**
+     * Adds a player to the Minecraft whitelist via {@code whitelist add <username>}.
+     *
+     * @param username the Minecraft username to whitelist
+     * @return the raw response text from the Minecraft server
+     * @throws IllegalArgumentException if the username is invalid
+     * @throws IOException              if the server cannot be reached or auth fails
+     */
+    public String addToWhitelist(String username) throws IOException {
+        if (!isValidUsername(username)) {
+            throw new IllegalArgumentException("Invalid Minecraft username: " + username);
+        }
+        try (RconClient client = new RconClient(host, port)) {
+            client.authenticate(password);
+            String response = client.sendCommand("whitelist add " + username);
+            log.info("RCON whitelist add '{}' -> '{}'", username, response);
+            return response;
+        }
+    }
+}

--- a/src/main/java/org/fitznet/util/RconClient.java
+++ b/src/main/java/org/fitznet/util/RconClient.java
@@ -1,0 +1,139 @@
+package org.fitznet.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Minimal client for the Source RCON protocol, used to send commands to a
+ * Minecraft server's remote console.
+ *
+ * <p>The protocol is intentionally tiny, so this is implemented directly over a
+ * TCP {@link Socket} rather than pulling in a dependency. Packets are little-endian:
+ * {@code int length | int requestId | int type | ASCII body + 0x00 | 0x00}.</p>
+ *
+ * <p>Note: long command output can be split across multiple response packets. The
+ * commands this bot sends (e.g. {@code whitelist add <user>}) return a single short
+ * line, so only the first response packet is read.</p>
+ */
+@Slf4j
+public class RconClient implements AutoCloseable {
+
+    /** SERVERDATA_AUTH — authentication request. */
+    public static final int TYPE_AUTH = 3;
+    /** SERVERDATA_EXECCOMMAND — command request (also the auth-response type). */
+    public static final int TYPE_COMMAND = 2;
+    /** SERVERDATA_RESPONSE_VALUE — command response (and the empty pre-auth response). */
+    public static final int TYPE_RESPONSE = 0;
+
+    private static final int AUTH_FAILED_ID = -1;
+    private static final int HEADER_AND_PADDING = Integer.BYTES * 2 + 2; // requestId + type + two null bytes
+    private static final int DEFAULT_TIMEOUT_MS = 5000;
+
+    private final Socket socket;
+    private final InputStream in;
+    private final OutputStream out;
+    private int requestCounter = 0;
+
+    public RconClient(String host, int port) throws IOException {
+        this(host, port, DEFAULT_TIMEOUT_MS);
+    }
+
+    public RconClient(String host, int port, int timeoutMs) throws IOException {
+        socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), timeoutMs);
+        socket.setSoTimeout(timeoutMs);
+        in = socket.getInputStream();
+        out = socket.getOutputStream();
+    }
+
+    /**
+     * Authenticates with the server. Must be called before {@link #sendCommand}.
+     *
+     * @throws IOException if the password is rejected or the connection fails
+     */
+    public void authenticate(String password) throws IOException {
+        int id = nextId();
+        writePacket(id, TYPE_AUTH, password);
+
+        // Some servers send an empty SERVERDATA_RESPONSE_VALUE before the auth response.
+        Packet response = readPacket();
+        if (response.type() == TYPE_RESPONSE) {
+            response = readPacket();
+        }
+        if (response.id() == AUTH_FAILED_ID) {
+            throw new IOException("RCON authentication failed (wrong password)");
+        }
+    }
+
+    /**
+     * Sends a command and returns the server's response text.
+     */
+    public String sendCommand(String command) throws IOException {
+        writePacket(nextId(), TYPE_COMMAND, command);
+        return readPacket().body();
+    }
+
+    private int nextId() {
+        return ++requestCounter;
+    }
+
+    private void writePacket(int id, int type, String body) throws IOException {
+        byte[] bodyBytes = body.getBytes(StandardCharsets.US_ASCII);
+        int length = HEADER_AND_PADDING + bodyBytes.length;
+        ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + length).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.putInt(length);
+        buffer.putInt(id);
+        buffer.putInt(type);
+        buffer.put(bodyBytes);
+        buffer.put((byte) 0); // body null terminator
+        buffer.put((byte) 0); // packet padding
+        out.write(buffer.array());
+        out.flush();
+    }
+
+    private Packet readPacket() throws IOException {
+        int length = readLittleEndianInt();
+        if (length < HEADER_AND_PADDING) {
+            throw new IOException("Invalid RCON packet length: " + length);
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(readFully(length)).order(ByteOrder.LITTLE_ENDIAN);
+        int id = buffer.getInt();
+        int type = buffer.getInt();
+        byte[] bodyBytes = new byte[length - HEADER_AND_PADDING];
+        buffer.get(bodyBytes);
+        return new Packet(id, type, new String(bodyBytes, StandardCharsets.US_ASCII));
+    }
+
+    private int readLittleEndianInt() throws IOException {
+        return ByteBuffer.wrap(readFully(Integer.BYTES)).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+
+    private byte[] readFully(int n) throws IOException {
+        byte[] data = new byte[n];
+        int offset = 0;
+        while (offset < n) {
+            int read = in.read(data, offset, n - offset);
+            if (read == -1) {
+                throw new IOException("Connection closed while reading RCON packet");
+            }
+            offset += read;
+        }
+        return data;
+    }
+
+    @Override
+    public void close() throws IOException {
+        socket.close();
+    }
+
+    private record Packet(int id, int type, String body) {
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,8 @@ joenet.sonarr.apikey=${JOENET_SONARR_APIKEY:your-api-key-here}
 joenet.sonarr.quality-profile-id=${JOENET_SONARR_QUALITY_PROFILE_ID:4}
 joenet.sonarr.root-folder-path=${JOENET_SONARR_ROOT_FOLDER_PATH:P:\\\\Plex\\\\Tv Shows}
 
+# Minecraft RCON Configuration (for /whitelist) - must match server.properties on the MC server
+minecraft.rcon.host=${MINECRAFT_RCON_HOST:your-mc-host-here}
+minecraft.rcon.port=${MINECRAFT_RCON_PORT:25575}
+minecraft.rcon.password=${MINECRAFT_RCON_PASSWORD:changeme}
+

--- a/src/test/java/org/fitznet/commands/WhitelistCommandsTest.java
+++ b/src/test/java/org/fitznet/commands/WhitelistCommandsTest.java
@@ -1,0 +1,145 @@
+package org.fitznet.commands;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
+import org.fitznet.data.GuildConfigDatabase;
+import org.fitznet.service.MinecraftRconService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class WhitelistCommandsTest {
+
+    @Mock private SlashCommandInteractionEvent event;
+    @Mock private Guild guild;
+    @Mock private Member member;
+    @Mock private User user;
+    @Mock private InteractionHook hook;
+    @Mock private WebhookMessageEditAction<Message> editAction;
+    @Mock private MinecraftRconService rconService;
+
+    private GuildConfigDatabase database;
+    private WhitelistCommands commands;
+
+    private static final long GUILD_ID = 999L;
+
+    @TempDir Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        database = new GuildConfigDatabase(tempDir.resolve("configs.json").toString());
+        commands = new WhitelistCommands(database, rconService);
+
+        when(event.getGuild()).thenReturn(guild);
+        when(event.getMember()).thenReturn(member);
+        when(event.getUser()).thenReturn(user);
+        when(event.getHook()).thenReturn(hook);
+        when(event.isFromGuild()).thenReturn(true);
+        when(event.isAcknowledged()).thenReturn(true);
+        when(guild.getIdLong()).thenReturn(GUILD_ID);
+        when(guild.getName()).thenReturn("Test Guild");
+        when(user.getName()).thenReturn("tester");
+        when(hook.editOriginal(anyString())).thenReturn(editAction);
+        doNothing().when(editAction).queue();
+    }
+
+    private void mockUsernameOption(String username) {
+        OptionMapping option = mock(OptionMapping.class);
+        when(option.getAsString()).thenReturn(username);
+        when(event.getOption("username")).thenReturn(option);
+    }
+
+    @Test
+    void getCommandsExposesWhitelistAndSetRole() {
+        SlashCommandData[] cmds = WhitelistCommands.getCommands();
+        assertEquals(2, cmds.length);
+        List<String> names = List.of(cmds[0].getName(), cmds[1].getName());
+        assertTrue(names.contains("whitelist"));
+        assertTrue(names.contains("setwhitelistrole"));
+    }
+
+    @Test
+    void deniesMemberWithoutRoleOrAdmin() {
+        when(event.getName()).thenReturn("whitelist");
+        when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(false);
+        when(member.getRoles()).thenReturn(List.of());
+        mockUsernameOption("Steve");
+
+        commands.onSlashCommandInteraction(event);
+
+        verify(hook).editOriginal(contains("don't have permission"));
+        verifyNoInteractions(rconService);
+    }
+
+    @Test
+    void adminCanWhitelistAndSeesServerResponse() throws Exception {
+        when(event.getName()).thenReturn("whitelist");
+        when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(true);
+        when(member.getEffectiveName()).thenReturn("Admin");
+        mockUsernameOption("Steve");
+        when(rconService.addToWhitelist("Steve")).thenReturn("Added Steve to the whitelist");
+
+        commands.onSlashCommandInteraction(event);
+
+        verify(rconService).addToWhitelist("Steve");
+        verify(hook).editOriginal(contains("Added Steve to the whitelist"));
+    }
+
+    @Test
+    void memberWithConfiguredRoleIsAllowed() throws Exception {
+        long roleId = 555L;
+        database.setWhitelistRoleId(GUILD_ID, roleId);
+        Role role = mock(Role.class);
+        when(role.getIdLong()).thenReturn(roleId);
+
+        when(event.getName()).thenReturn("whitelist");
+        when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(false);
+        when(member.getRoles()).thenReturn(List.of(role));
+        when(member.getEffectiveName()).thenReturn("Trusted");
+        mockUsernameOption("Notch");
+        when(rconService.addToWhitelist("Notch")).thenReturn("Added Notch to the whitelist");
+
+        commands.onSlashCommandInteraction(event);
+
+        verify(rconService).addToWhitelist("Notch");
+        verify(hook).editOriginal(contains("Added Notch to the whitelist"));
+    }
+
+    @Test
+    void rejectsInvalidUsernameWithoutCallingRcon() throws Exception {
+        when(event.getName()).thenReturn("whitelist");
+        when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(true);
+        mockUsernameOption("bad name!");
+
+        commands.onSlashCommandInteraction(event);
+
+        verify(hook).editOriginal(contains("valid Minecraft username"));
+        verify(rconService, never()).addToWhitelist(anyString());
+    }
+}

--- a/src/test/java/org/fitznet/service/MinecraftRconServiceTest.java
+++ b/src/test/java/org/fitznet/service/MinecraftRconServiceTest.java
@@ -1,0 +1,44 @@
+package org.fitznet.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MinecraftRconServiceTest {
+
+    @Test
+    void acceptsValidUsernames() {
+        assertTrue(MinecraftRconService.isValidUsername("Steve"));
+        assertTrue(MinecraftRconService.isValidUsername("Notch_99"));
+        assertTrue(MinecraftRconService.isValidUsername("abc"));              // 3 chars (minimum)
+        assertTrue(MinecraftRconService.isValidUsername("A1234567890_abcd")); // 16 chars (maximum)
+    }
+
+    @Test
+    void rejectsInvalidUsernames() {
+        assertFalse(MinecraftRconService.isValidUsername(null));
+        assertFalse(MinecraftRconService.isValidUsername(""));
+        assertFalse(MinecraftRconService.isValidUsername("ab"));                // too short
+        assertFalse(MinecraftRconService.isValidUsername("ThisNameIsTooLong")); // 17 chars
+        assertFalse(MinecraftRconService.isValidUsername("has space"));
+        assertFalse(MinecraftRconService.isValidUsername("dash-name"));
+    }
+
+    @Test
+    void rejectsRconInjectionAttempts() {
+        // Spaces / newlines / separators must never reach the server, where they
+        // could be interpreted as additional RCON commands.
+        assertFalse(MinecraftRconService.isValidUsername("Steve op @a"));
+        assertFalse(MinecraftRconService.isValidUsername("Steve\nop"));
+        assertFalse(MinecraftRconService.isValidUsername("Steve;stop"));
+    }
+
+    @Test
+    void addToWhitelistRejectsInvalidUsernameWithoutConnecting() {
+        MinecraftRconService service = new MinecraftRconService();
+        // No RCON host configured; an invalid username must fail before any socket is opened.
+        assertThrows(IllegalArgumentException.class, () -> service.addToWhitelist("bad name"));
+    }
+}

--- a/src/test/java/org/fitznet/util/RconClientTest.java
+++ b/src/test/java/org/fitznet/util/RconClientTest.java
@@ -1,0 +1,128 @@
+package org.fitznet.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RconClientTest {
+
+    @Test
+    void authenticatesAndReturnsCommandResponse() throws Exception {
+        String expected = "Added Steve to the whitelist";
+        try (FakeRconServer server = new FakeRconServer(expected)) {
+            try (RconClient client = new RconClient("127.0.0.1", server.getPort(), 2000)) {
+                client.authenticate("secret");
+                assertEquals(expected, client.sendCommand("whitelist add Steve"));
+            }
+            assertEquals("whitelist add Steve", server.getReceivedCommand());
+        }
+    }
+
+    @Test
+    void throwsWhenAuthenticationFails() throws Exception {
+        try (FakeRconServer server = new FakeRconServer("ignored").rejectAuth()) {
+            try (RconClient client = new RconClient("127.0.0.1", server.getPort(), 2000)) {
+                assertThrows(IOException.class, () -> client.authenticate("wrong"));
+            }
+        }
+    }
+
+    /** Minimal in-process RCON server that exercises the client end-to-end. */
+    private static class FakeRconServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private volatile String receivedCommand;
+        private volatile boolean rejectAuth = false;
+
+        FakeRconServer(String commandResponse) throws IOException {
+            serverSocket = new ServerSocket(0);
+            Thread thread = new Thread(() -> run(commandResponse));
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        FakeRconServer rejectAuth() {
+            this.rejectAuth = true;
+            return this;
+        }
+
+        int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        String getReceivedCommand() {
+            return receivedCommand;
+        }
+
+        private void run(String commandResponse) {
+            try (Socket socket = serverSocket.accept()) {
+                InputStream in = socket.getInputStream();
+                OutputStream out = socket.getOutputStream();
+
+                // Auth request -> auth response (id -1 signals failure).
+                Packet auth = readPacket(in);
+                writePacket(out, rejectAuth ? -1 : auth.id(), RconClient.TYPE_COMMAND, "");
+                if (rejectAuth) {
+                    return;
+                }
+
+                // Command request -> response value.
+                Packet command = readPacket(in);
+                receivedCommand = command.body();
+                writePacket(out, command.id(), RconClient.TYPE_RESPONSE, commandResponse);
+            } catch (IOException ignored) {
+                // socket closed by the test — expected on teardown
+            }
+        }
+
+        private static Packet readPacket(InputStream in) throws IOException {
+            int length = readInt(in);
+            byte[] payload = in.readNBytes(length);
+            ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+            int id = buffer.getInt();
+            int type = buffer.getInt();
+            byte[] body = new byte[length - 10];
+            buffer.get(body);
+            return new Packet(id, type, new String(body, StandardCharsets.US_ASCII));
+        }
+
+        private static int readInt(InputStream in) throws IOException {
+            byte[] b = in.readNBytes(Integer.BYTES);
+            if (b.length < Integer.BYTES) {
+                throw new IOException("stream closed");
+            }
+            return ByteBuffer.wrap(b).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        }
+
+        private static void writePacket(OutputStream out, int id, int type, String body) throws IOException {
+            byte[] bodyBytes = body.getBytes(StandardCharsets.US_ASCII);
+            int length = 10 + bodyBytes.length; // id + type + body + two null bytes
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + length).order(ByteOrder.LITTLE_ENDIAN);
+            buffer.putInt(length);
+            buffer.putInt(id);
+            buffer.putInt(type);
+            buffer.put(bodyBytes);
+            buffer.put((byte) 0);
+            buffer.put((byte) 0);
+            out.write(buffer.array());
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+        }
+
+        private record Packet(int id, int type, String body) {
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a role-gated **`/whitelist <username>`** slash command that adds players to the Minecraft server's whitelist over **RCON**, plus **`/setwhitelistrole`** for admins to pick which Discord role may use it.

## Why

The Minecraft server (on a separate VM adjacent to the Docker host) was seeing anonymous crawlers/bots connect. With `white-list=true` + `online-mode=true` on the server, only authenticated, whitelisted players can join — and this command lets trusted members manage that list from Discord without server access.

## Changes

- **`RconClient`** — minimal self-contained Source RCON client over a TCP socket (no new dependency).
- **`MinecraftRconService`** — validates usernames against Minecraft's rules (`3-16` `[A-Za-z0-9_]`), which also blocks RCON command injection, then sends `whitelist add <user>`.
- **`WhitelistCommands`** — deferred ephemeral replies, admin/role gating, surfaces the server's response; registered in `BotService` alongside the other handlers.
- **`GuildConfig` / `GuildConfigDatabase`** — persist `whitelistRoleId` per guild (mirrors `botChannelId`).
- **Config** — `minecraft.rcon.host/port/password` with env overrides in `application.properties`.

## Access control

`/whitelist` is allowed for administrators or members holding the role set via `/setwhitelistrole` (Manage Server). If no role is configured, only admins can use it.

## Tests

`./gradlew test` green. New: username validation + injection attempts, an RCON protocol round-trip against an in-process fake server, and command role-gating (deny / admin / configured-role / invalid-username).

## Server-side prerequisite (not in this repo)

In `server.properties`: `white-list=true`, `enforce-whitelist=true`, `online-mode=true`, `enable-rcon=true`, `rcon.port`, `rcon.password`. Documented in the README and in `Fitz-Net/docs/fitz-bot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)