### PR TITLE
feat(deploy): inject Minecraft RCON host/password into bot launch

### DIFF
--- a/.github/workflows/Deployment.yml
+++ b/.github/workflows/Deployment.yml
@@ -215,6 +215,8 @@ jobs:
             --joenet.radarr.apikey='${{ secrets.JOENET_RADARR_APIKEY }}' \
             --joenet.sonarr.port='${{ secrets.JOENET_SONARR_PORT }}' \
             --joenet.sonarr.apikey='${{ secrets.JOENET_SONARR_APIKEY }}' \
+            --minecraft.rcon.host='${{ secrets.MINECRAFT_RCON_HOST }}' \
+            --minecraft.rcon.password='${{ secrets.MINECRAFT_RCON_PASSWORD }}' \
             --spring.config.additional-location=classpath:/,file:config/application.properties \
             > logs/fitz-bot.log 2>&1 &
           APP_PID=$!; echo "Started with PID: $APP_PID"; sleep 6;


### PR DESCRIPTION
## What
Wires the new `MINECRAFT_RCON_HOST` and `MINECRAFT_RCON_PASSWORD` repo secrets into the deploy workflow's launch step:

```bash
--minecraft.rcon.host='${{ secrets.MINECRAFT_RCON_HOST }}' \
--minecraft.rcon.password='${{ secrets.MINECRAFT_RCON_PASSWORD }}' \
```

## Why
The `/whitelist` command (added in v0.25.0) reads `minecraft.rcon.*`, but the deploy workflow never passed these values to `java`. The app was falling back to the packaged defaults (`your-mc-host-here` / `changeme`), so RCON could not reach the server in production.

- Host: `192.168.1.93` (set as `MINECRAFT_RCON_HOST`)
- Password: set as `MINECRAFT_RCON_PASSWORD`
- Port: left at the packaged `25575` default (not parameterized)

## Notes
Secrets are injected as CLI args, consistent with the existing Discord/JoeNet pattern. (Same process-list caveat applies as the other secrets — visible via `ps` on the Pi.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)