### PR TITLE
fix(deploy): stop the actual running bot process before deploying

### DIFF
--- a/.github/workflows/Deployment.yml
+++ b/.github/workflows/Deployment.yml
@@ -121,11 +121,19 @@ jobs:
             echo 'ℹ️  fitz-bot service not running'
           fi
           
-          # Kill any running Java processes for the bot (backup method)
-          if pgrep -f 'fitz.*jar' > /dev/null 2>&1; then
-            echo 'Killing existing bot processes...'
-            pkill -f 'fitz.*jar' 2>/dev/null || true
-            sleep 2
+          # Kill the running bot JVM. Match 'current.jar' to stay consistent with how
+          # the app is started ('java -jar current.jar') and health-checked. The old
+          # 'fitz.*jar' pattern never matched the running cmdline, so stale processes
+          # survived deploys and had to be killed by hand.
+          if pgrep -f 'current.jar' > /dev/null 2>&1; then
+            echo 'Stopping existing bot process (SIGTERM)...'
+            pkill -f 'current.jar' 2>/dev/null || true
+            sleep 5
+            if pgrep -f 'current.jar' > /dev/null 2>&1; then
+              echo 'Still alive after grace period, sending SIGKILL...'
+              pkill -9 -f 'current.jar' 2>/dev/null || true
+              sleep 1
+            fi
             echo '✅ Stopped existing processes'
           else
             echo 'ℹ️  No existing bot processes found'


### PR DESCRIPTION
## Problem
Deploys were leaving the **old** bot process running, forcing a manual \`killall java\` (and causing port 8080 conflicts / the stale JAR to keep running).

Root cause: the stop step matched the wrong process pattern.

| Step | Pattern |
|------|---------|
| Start | `java -jar current.jar …` |
| Health check | `pgrep -f 'current.jar'` |
| **Stop (buggy)** | `pgrep -f 'fitz.*jar'` ← never matches |

The running command line is `java -jar current.jar --discord.bot.token=…` — there's no literal `fitz…jar` in it, so `fitz.*jar` matched nothing and the old JVM was never killed.

## Fix
- Match `current.jar`, consistent with how the app is started and health-checked.
- Graceful shutdown: `SIGTERM` → 5s grace → `SIGKILL` fallback, so it's reliable without a blanket `killall java` (which would kill any unrelated JVM on the host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)