### PR TITLE
chore(ci): uplift deprecated GitHub Actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -22,18 +22,21 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Fetch all history for tags
 
     - name: ☕ Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
+    - name: ✅ Validate Gradle wrapper
+      uses: gradle/actions/wrapper-validation@v5
+
     - name: 🔧 Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v5
 
     - name: 🔨 Make gradlew executable
       run: chmod +x ./gradlew
@@ -62,7 +65,7 @@ jobs:
         echo "::endgroup::"
 
     - name: 📤 Upload JAR artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: application-jar
         path: ${{ steps.build.outputs.jar-path }}
@@ -118,7 +121,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -201,7 +204,7 @@ jobs:
         echo "::endgroup::"
 
     - name: 📥 Download original JAR
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: application-jar
         path: ./downloaded-jar

--- a/.github/workflows/Deployment.yml
+++ b/.github/workflows/Deployment.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: 🔍 Get deployment version
       id: version


### PR DESCRIPTION
Uplifts deprecated/outdated GitHub Actions to current versions, aligning this repo's CI with the already-modernized sibling Java repos (`fitz-net-api`, `GamerBell`).

**`.github/workflows/Build.yml`**
- Replace the **deprecated** `gradle/gradle-build-action@v2` with `gradle/actions/setup-gradle@v5`
- Add a `gradle/actions/wrapper-validation@v5` step (matches sibling Java repos)
- `actions/checkout@v4` → `@v6`
- `actions/setup-java@v4` → `@v5`
- CI JDK `17` → `21` (matches the documented Java 21 stack; build has no `sourceCompatibility` pin)
- `actions/upload-artifact@v4` → `@v6`, `actions/download-artifact@v4` → `@v7`

**`.github/workflows/Deployment.yml`**
- `actions/checkout@v4` → `@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)