### PR TITLE
fix(config): share GuildConfigDatabase so requester logs post

### DIFF
--- a/src/main/java/org/fitznet/commands/ConfigCommands.java
+++ b/src/main/java/org/fitznet/commands/ConfigCommands.java
@@ -9,23 +9,17 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.fitznet.data.GuildConfigDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Slash command handler for bot configuration commands.
  */
 @Slf4j
+@Component
 public class ConfigCommands extends ListenerAdapter {
-    private final GuildConfigDatabase configDatabase;
-
-    public ConfigCommands() {
-        try {
-            this.configDatabase = new GuildConfigDatabase();
-            log.info("ConfigCommands initialized successfully");
-        } catch (Exception e) {
-            log.error("Failed to initialize ConfigCommands", e);
-            throw e;
-        }
-    }
+    @Autowired
+    private GuildConfigDatabase configDatabase;
 
     /**
      * Gets the slash command definitions.

--- a/src/main/java/org/fitznet/commands/JoenetCommands.java
+++ b/src/main/java/org/fitznet/commands/JoenetCommands.java
@@ -55,7 +55,8 @@ public class JoenetCommands extends ListenerAdapter {
     @Autowired
     private SonarrService sonarrService;
 
-    private GuildConfigDatabase configDatabase = new GuildConfigDatabase();
+    @Autowired
+    private GuildConfigDatabase configDatabase;
 
     /**
      * Gets the slash command definitions.

--- a/src/main/java/org/fitznet/commands/WhitelistCommands.java
+++ b/src/main/java/org/fitznet/commands/WhitelistCommands.java
@@ -35,12 +35,7 @@ public class WhitelistCommands extends ListenerAdapter {
     private final MinecraftRconService rconService;
 
     @Autowired
-    public WhitelistCommands(MinecraftRconService rconService) {
-        this(new GuildConfigDatabase(), rconService);
-    }
-
-    /** Package-private constructor for testing with an injected database. */
-    WhitelistCommands(GuildConfigDatabase configDatabase, MinecraftRconService rconService) {
+    public WhitelistCommands(GuildConfigDatabase configDatabase, MinecraftRconService rconService) {
         this.configDatabase = configDatabase;
         this.rconService = rconService;
     }

--- a/src/main/java/org/fitznet/data/GuildConfigDatabase.java
+++ b/src/main/java/org/fitznet/data/GuildConfigDatabase.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.fitznet.data.model.GuildConfig;
 import org.fitznet.util.Constants;
 import org.fitznet.util.JsonUtils;
+import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,8 +15,13 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Database for storing guild-specific configuration settings.
  * Each guild can have its own bot channel and other settings.
+ *
+ * <p>Registered as a singleton Spring bean so every listener/command shares the same
+ * in-memory cache and file. Instantiating separate copies would let each hold a stale
+ * view and clobber the others' writes to {@code data/guild_configs.json}.</p>
  */
 @Slf4j
+@Component
 public class GuildConfigDatabase {
     private final Map<Long, GuildConfig> guildConfigs = new ConcurrentHashMap<>();
     private final String configFile;

--- a/src/main/java/org/fitznet/listener/LoginListener.java
+++ b/src/main/java/org/fitznet/listener/LoginListener.java
@@ -11,22 +11,20 @@ import org.fitznet.data.GuildConfigDatabase;
 import org.fitznet.util.Constants;
 import org.fitznet.util.EmbedUtil;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Discord event listener that tracks voice channel joins.
  * Maintains voice join counts in persistent storage and sends milestone congratulations.
  */
 @Slf4j
+@Component
 public class LoginListener extends ListenerAdapter {
     private final int[] loginMilestones = Constants.DEFAULT_MILESTONES;
-    private final GuildConfigDatabase configDatabase;
 
-    /**
-     * Constructs a new LoginListener.
-     */
-    public LoginListener() {
-        this.configDatabase = new GuildConfigDatabase();
-    }
+    @Autowired
+    private GuildConfigDatabase configDatabase;
 
     /**
      * Handles guild voice update events from Discord.

--- a/src/main/java/org/fitznet/service/BotService.java
+++ b/src/main/java/org/fitznet/service/BotService.java
@@ -35,6 +35,12 @@ public class BotService {
     @Autowired
     private WhitelistCommands whitelistCommands;
 
+    @Autowired
+    private LoginListener loginListener;
+
+    @Autowired
+    private ConfigCommands configCommands;
+
     /**
      * -- GETTER --
      *  Gets the JDA instance.
@@ -62,8 +68,8 @@ public class BotService {
                     .build().awaitReady();
 
             // Add event listeners
-            jda.addEventListener(new LoginListener());
-            jda.addEventListener(new ConfigCommands());
+            jda.addEventListener(loginListener);
+            jda.addEventListener(configCommands);
             jda.addEventListener(joenetCommands);
             jda.addEventListener(whitelistCommands);
 


### PR DESCRIPTION
## Problem

The requester-log feature added in #48 (`/setrequesterlogchannel` + post-download logs for `/joenet download`) lets you set and store a channel, but **no requester-log message is ever posted**.

## Root cause

Each listener/command constructed its **own** `GuildConfigDatabase` over the same `data/guild_configs.json` file, so each held a separate in-memory map:

- `ConfigCommands` (the writer) → `new GuildConfigDatabase()`
- `JoenetCommands` (the reader) → `private GuildConfigDatabase configDatabase = new GuildConfigDatabase();`

`/setrequesterlogchannel` wrote the channel into `ConfigCommands`' instance. When `JoenetCommands.postRequesterLog(...)` ran, it read `getRequesterLogChannelId(...)` from its **own separate instance**, which never saw the write, got `null`, and returned early before calling `channel.sendMessage(...)`. Additionally, because every instance's `saveConfigs()` rewrites the whole file, the instances silently clobbered each other's persisted config.

## Fix

Make `GuildConfigDatabase` a single shared Spring `@Component` bean and inject the same instance into every consumer:

- `GuildConfigDatabase` → `@Component`
- `JoenetCommands`, `ConfigCommands`, `LoginListener` → `@Autowired` the shared bean (field injection)
- `WhitelistCommands` → constructor now injects the bean instead of `new`-ing one
- `BotService` → registers the injected `ConfigCommands`/`LoginListener` beans instead of `new` instances

This fixes the requester logs and also hardens the milestone (`/setbotchannel`) and whitelist config paths against the same stale-read / mutual-clobber bug.

## Testing

- `./gradlew clean test` — all 142 tests pass (JDK 21). No test changes were needed; existing tests inject the DB via reflection on the `configDatabase` field, which the new field injection preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)